### PR TITLE
【PT-24】ツイート一覧画面改修

### DIFF
--- a/www/PackTweet/application/controllers/Tweets.php
+++ b/www/PackTweet/application/controllers/Tweets.php
@@ -101,11 +101,12 @@ class Tweets extends CI_Controller
 
 		public function mypage()
 		{
-				$userId = $_SESSION['user_id'];
-				$data['tweets'] = $this->tweet_model->getByUserId($userId);
-				$this->load->view('common/header');
-				$this->load->view('common/sidebar');
-				$this->load->view('users/mypage', $data);
+            $userId = $_SESSION['user_id'];
+            $data['tweets'] = $this->tweet_model->getByUserId($userId);
+            $data['favorites'] = $this->favorite_model->getByUserId($userId);
+            $this->load->view('common/header');
+            $this->load->view('common/sidebar');
+            $this->load->view('users/mypage', $data);
 		}
 
     public function favorite()

--- a/www/PackTweet/application/controllers/Tweets.php
+++ b/www/PackTweet/application/controllers/Tweets.php
@@ -33,18 +33,24 @@ class Tweets extends CI_Controller
 
 		public function store()
 		{
-        $this->form_validation->set_rules('content', 'ツイート', 'required|max_length[140]', [
-          'required' => '%sは必須です。',
-          'max_length' => '{param}文字以内で入力してください。',
-        ]);
+            $this->form_validation->set_rules('content', 'ツイート', 'required|max_length[140]', [
+                'required' => '%sは必須です。',
+                'max_length' => '{param}文字以内で入力してください。',
+            ]);
 
-        if (!$this->form_validation->run()) {
-						$this->load->view('common/header');
-            return $this->load->view('users/create_tweet');
-        }
+            $urlArray = parse_url($_SERVER['HTTP_REFERER']);
 
-				$this->tweet_model->createTweet();
-        redirect('/');
+            if (!$this->form_validation->run()) {
+                if ($urlArray['path'] === '/tweets/create') {
+                    $this->load->view('common/header');
+                    return $this->load->view('users/create_tweet');
+                } else {
+                    return $this->index();
+                }
+            }
+
+            $this->tweet_model->createTweet();
+            redirect('/');
 		}
 
 		public function show($tweetId)

--- a/www/PackTweet/application/models/Favorite_model.php
+++ b/www/PackTweet/application/models/Favorite_model.php
@@ -41,4 +41,16 @@ class Favorite_model extends CI_Model
             return false;
         }
     }
+
+    public function getByUserId($userId)
+    {
+        $getTweets = '(select tweets.id, content, tweets.created_at ,name from tweets left outer join users on users.id = tweets.user_id)';
+
+        $this->db->select('user_id AS favorite_user_id, name, content, tweets_users.created_at AS tweet_time, favorites.created_at AS favorite_time, favorites.tweet_id');
+        $this->db->where('favorites.user_id', $userId);
+        $this->db->join($getTweets . ' AS tweets_users', 'tweets_users.id = favorites.tweet_id', 'left');
+        $this->db->order_by('favorite_time', 'desc');
+        $query = $this->db->get('favorites');
+        return $query->result_array();
+    }
 }

--- a/www/PackTweet/application/public/css/app.css
+++ b/www/PackTweet/application/public/css/app.css
@@ -287,12 +287,12 @@ fieldset[disabled] a.btn {
 fieldset[disabled] .btn-success:hover,
 fieldset[disabled] .btn-success:focus,
 fieldset[disabled] .btn-success.focus {
-  background-color: #2ab27b;
-  border-color: #259d6d;
+  background-color: #00acee;
+  border-color: #00acee;
 }
 
 .btn-success .badge {
-  color: #2ab27b;
+  color: #00acee;
   background-color: #fff;
 }
 
@@ -389,7 +389,7 @@ fieldset[disabled] .btn-success.focus {
   border-bottom: 0.5px solid #c0c0c0;
 }
 
-.mypage-tweet:hover {
+.mypage-tweet:hover, .index-tweet:hover {
   background-color: rgba(0, 0, 0, 0.03);
 }
 
@@ -456,4 +456,40 @@ fieldset[disabled] .btn-success.focus {
 
 .select-tab {
   border-bottom: 2px solid #00acee;
+}
+
+.index-container {
+  background-color: #ffffff;
+  border: 0.5px solid #c0c0c0;
+  padding: 0;
+}
+
+.index-title {
+  display: flex;
+  padding: 0 0 10px 10px;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  border-bottom: 0.5px solid #c0c0c0;
+}
+
+.index-form-group {
+  height: 200px;
+  width: 90%;
+  margin: 0 auto;
+}
+
+.index-group {
+  padding: 0 20px 15px 20px;
+  margin-bottom: 0;
+}
+
+.index-tweet {
+  display: block;
+  text-decoration: none;
+  color: #636b6f;
+  border-top: 0.5px solid #c0c0c0;
+}
+
+.index-help-block {
+  margin-bottom: 0;
 }

--- a/www/PackTweet/application/public/css/index.css
+++ b/www/PackTweet/application/public/css/index.css
@@ -65,5 +65,6 @@
 	display: flex;
 	justify-content: center;
 	margin-top: 50px;
+	margin-bottom: 100%;
 }
 

--- a/www/PackTweet/application/public/css/nav-fix.css
+++ b/www/PackTweet/application/public/css/nav-fix.css
@@ -38,7 +38,7 @@
 		left:100%;right:auto;border-radius:0 3px 3px 0}
 		.navbar-fixed-left .dropdown .dropdown-toggle .caret{border-top:4px solid transparent;border-left:4px solid;border-bottom:4px solid transparent;border-right:none}}
 
-		@media (min-width:768px){.mypage-container{width:453px}}
-		@media (min-width:992px){.mypage-container{width:683px}}
-		@media (min-width:1200px){.mypage-container{width:873px}}
-		@media (min-width:1432px){.mypage-container{width:1120px}}
+		@media (min-width:768px){.mypage-container, .index-container{width:403px}}
+		@media (min-width:992px){.mypage-container, .index-container{width:633px}}
+		@media (min-width:1200px){.mypage-container, .index-container{width:673px}}
+		@media (min-width:1432px){.mypage-container, .index-container{width:920px}}

--- a/www/PackTweet/application/public/js/tweet_btn.js
+++ b/www/PackTweet/application/public/js/tweet_btn.js
@@ -1,0 +1,18 @@
+$(function() {
+  // $('#search-input-box').on('input', function() {
+  //   var input = $(this).val();
+  //   if(input) {
+  //     $('#search-btn').prop('disabled', false);
+  //   } else {
+  //     $('#search-btn').prop('disabled', true);
+  //   }
+  // });
+  $('.tweet-textarea').on('input', function() {
+    var input = $(this).val();
+    if(input) {
+      $('.tweet-btn').prop('disabled', false);
+    } else {
+      $('.tweet-btn').prop('disabled', true);
+    }
+  });
+});

--- a/www/PackTweet/application/views/common/sidebar.php
+++ b/www/PackTweet/application/views/common/sidebar.php
@@ -4,10 +4,10 @@
 		<div class="navbar-collapse collapse">
 			<ul class="nav-left-list">
 				<li>
-					<a href="#"><i class="fab fa-twitter fa-2x"></i></a>
+					<a href="<?= site_url('tweets'); ?>"><i class="fab fa-twitter fa-2x"></i></a>
 				</li>
 				<li>
-					<a href="#"><i class="fas fa-home"></i>&nbsp;&nbsp;ホーム</a>
+					<a href="<?= site_url('tweets'); ?>"><i class="fas fa-home"></i>&nbsp;&nbsp;ホーム</a>
 				</li>
 				<li>
 					<a href="#"><i class="fas fa-hashtag"></i>&nbsp;&nbsp;話題を検索</a>

--- a/www/PackTweet/application/views/users/index_tweet.php
+++ b/www/PackTweet/application/views/users/index_tweet.php
@@ -1,5 +1,5 @@
 <div class="main-wrap">
-  <div class="content-wrapper table-responsive">
+  <!-- <div class="content-wrapper table-responsive">
     <div class="tweet-boxes">
       <? if (count($tweets) === 0): ?>
         <div class="no-result-alert">
@@ -27,6 +27,45 @@
         <?= form_close() ?>
       </div>
     </div>
+  </div> -->
+  <div class="container index-container">
+      <div>
+        <? if (count($tweets) === 0): ?>
+          <div class="no-result-alert">
+            <?= $search_word ?>の検索結果はありませんでした。
+          </div>
+        <? else: ?>
+          <div class="title index-title">
+            <div class="name-tweets-container">
+              <span>ホーム</span>
+            </div>
+          </div>
+          <?= form_open('tweets/create', ['method'=>'POST']); ?>
+            <div class="form-group index-form-group">
+              <?= form_textarea(['name' => 'content',  'class' => 'form-control index-form-control tweet-textarea', 'placeholder' => 'いまどうしてる？', 'cols' => '20', 'rows' => '5', 'maxlength' => 140]); ?>
+              <span class="help-block index-help-block"><?= form_error('content'); ?></span>
+              <button type="submit" class="btn btn-success pull-right tweet-btn" disabled>ツイートする</button>
+            </div>
+          <?= form_close(); ?>
+          <? foreach ($tweets as $tweet): ?>
+          <a class="index-tweet" href="<?= site_url('tweets/' . $tweet['tweet_id']); ?>">
+            <div class="form-group index-group">
+              <?php if ($tweet['retweet_or_not'] && $tweet['retweet_or_not'] != '1'): ?>
+                <div class=""><i class="fas fa-retweet">リツイート済み</i></div>
+              <?php endif; ?>
+              <p class="user-name">&nbsp;<i class="user-name-font"><?= $tweet['name'] ?></i>&nbsp;&nbsp;&nbsp;<?= date('Y年n月d日 ', strtotime($tweet['created_at'])) ?></p>
+              <div class="tweet-content mypage-tweet-content"><?= $tweet['content'] ?></div>
+            </div>
+          </a>
+          <? endforeach; ?>
+        <? endif ?>
+      </div>
+      <div class="search-box">
+        <?= form_open('tweets', ['method' => 'GET']) ?>
+          <button type="submit" name="submit" id="search-btn" disabled><i class="fas fa-search fa-2x"></i></button>
+          <?= form_input(['name' => 'search_word', 'class' => 'input-box', 'id' => 'search-input-box', 'value' => $search_word]) ?>
+        <?= form_close() ?>
+      </div>
   </div>
   <div class="modal js-modal">
     <div class="modal-bg js-modal-close"></div>
@@ -35,9 +74,9 @@
         <a class="js-modal-close">✖️</a>
       </div>
       <?= form_open('tweets/create', ['class' => 'modal-form']); ?>
-        <?= form_textarea(['name' => 'content',  'class' => 'form-control modal-text', 'placeholder' => 'いまどうしてる？', 'cols' => '50', 'rows' => '10', 'maxlength' => 140]); ?>
+        <?= form_textarea(['name' => 'content',  'class' => 'form-control modal-text tweet-textarea', 'placeholder' => 'いまどうしてる？', 'cols' => '50', 'rows' => '10', 'maxlength' => 140]); ?>
         <span class="help-block modal-validate"></span>
-        <?= form_button(['type' => 'submit', 'class' => 'btn btn-success pull-right modal-submit', 'content' => "ツイートする"]) ?>
+        <button type="submit", class="btn btn-success pull-right modal-submit tweet-btn" disabled>ツイートする</button>
       <?= form_close(); ?>
     </div>
   </div>
@@ -45,5 +84,6 @@
   <script src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
   <script src="application/public/js/modal.js"></script>
   <script src="application/public/js/search_btn.js"></script>
+  <script src="application/public/js/tweet_btn.js"></script>
 </body>
 </html>

--- a/www/PackTweet/application/views/users/index_tweet.php
+++ b/www/PackTweet/application/views/users/index_tweet.php
@@ -1,33 +1,4 @@
 <div class="main-wrap">
-  <!-- <div class="content-wrapper table-responsive">
-    <div class="tweet-boxes">
-      <? if (count($tweets) === 0): ?>
-        <div class="no-result-alert">
-          <?= $search_word ?>の検索結果はありませんでした。
-        </div>
-      <? else: ?>
-        <? foreach ($tweets as $tweet) : ?>
-          <a href="<?= site_url('tweets/'. $tweet['tweet_id'] ) ?>">
-            <div class="tweet-box">
-              <?php if ($tweet['retweet_or_not'] && $tweet['retweet_or_not'] != '1'): ?>
-                <div class="retweet-index"><i class="fas fa-retweet">&nbsp;&nbsp;<?= $tweet['retweet_or_not'] ?>さんがリツイートしました。</i></div>
-              <?php endif; ?>
-              <div class="user-info"><?= $tweet['name'] ?></div>
-              <div class="tweet-index-content"><?= $tweet['content'] ?></div>
-              <div class="tweet-index-created-at"><?= $tweet['created_at'] ?></div>
-            </div>
-          </a>
-        <? endforeach; ?>
-      <? endif ?>
-    </div>
-      <div class="search-box">
-        <?= form_open('tweets', ['method' => 'GET']) ?>
-          <button type="submit" name="submit" id="search-btn" disabled><i class="fas fa-search fa-2x"></i></button>
-          <?= form_input(['name' => 'search_word', 'class' => 'input-box', 'id' => 'search-input-box', 'value' => $search_word]) ?>
-        <?= form_close() ?>
-      </div>
-    </div>
-  </div> -->
   <div class="container index-container">
       <div>
         <? if (count($tweets) === 0): ?>

--- a/www/PackTweet/application/views/users/mypage.php
+++ b/www/PackTweet/application/views/users/mypage.php
@@ -36,7 +36,22 @@
       </div>
       <!--  -->
     </div>
+    <div class="modal js-modal">
+      <div class="modal-bg js-modal-close"></div>
+      <div class="modal-content">
+        <div>
+          <a class="js-modal-close">✖️</a>
+        </div>
+        <?= form_open('tweets/create', ['class' => 'modal-form']); ?>
+          <?= form_textarea(['name' => 'content',  'class' => 'form-control modal-text', 'placeholder' => 'いまどうしてる？', 'cols' => '50', 'rows' => '10', 'maxlength' => 140]); ?>
+          <span class="help-block modal-validate"></span>
+          <?= form_button(['type' => 'submit', 'class' => 'btn btn-success pull-right modal-submit', 'content' => "ツイートする"]) ?>
+        <?= form_close(); ?>
+      </div>
+    </div>
   <script src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
   <script src="application/public/js/mypage_tab.js"></script>
+  <script src="application/public/js/modal.js"></script>
+  <script src="application/public/js/tweet_btn.js"></script>
 </body>
 </html>

--- a/www/PackTweet/application/views/users/mypage.php
+++ b/www/PackTweet/application/views/users/mypage.php
@@ -25,16 +25,16 @@
         </a>
       <? endforeach; ?>
       </div>
-      <!-- 以下はダミー(いいねしたツイート表示) -->
       <div class="tab-content is-hidden">
-        <a class="mypage-tweet" href="">
-          <div class="form-group show-form-group">
-            <p class="user-name">&nbsp;<i class="user-name-font">hoge</li>&nbsp;&nbsp;&nbsp;2021年7月30日</p>
-            <div class="tweet-content mypage-tweet-content">いいねしたツイートを表示</div>
-          </div>
-        </a>
+        <? foreach ($favorites as $favorite): ?>
+          <a class="mypage-tweet" href="<?= site_url('tweets/' . $favorite['tweet_id']); ?>">
+            <div class="form-group show-form-group">
+              <p class="user-name">&nbsp;<i class="user-name-font"><?= $favorite['name'] ?></i>&nbsp;&nbsp;&nbsp;<?= date('Y年n月d日 ', strtotime($favorite['tweet_time'])) ?></p>
+              <div class="tweet-content mypage-tweet-content"><?= $favorite['content'] ?></div>
+            </div>
+          </a>
+        <? endforeach; ?>
       </div>
-      <!--  -->
     </div>
     <div class="modal js-modal">
       <div class="modal-bg js-modal-close"></div>


### PR DESCRIPTION
- ツイート作成時に、遷移前URLによってバリデーションエラー後の表示先変更
- ツイートが入力されてなかった場合ボタン押せないように修正
- mypageでもモーダル表示できるように修正
- 一覧画面のレイアウト修正
- いいねしたツイートをマイページに表示